### PR TITLE
Fix upstream keepalive, persist backup timer, restrict CI token

### DIFF
--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -2,6 +2,9 @@ name: Lint nginx configuration
 
 on: [pull_request, push]
 
+permissions:
+  contents: read
+
 jobs:
   static:
     runs-on: ubuntu-latest

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -141,6 +141,7 @@ http {
 
     map $http_upgrade $connection_upgrade {
         default upgrade;
+        '' '';
     }
 
     upstream backend {

--- a/systemd/system/remote-backup.timer
+++ b/systemd/system/remote-backup.timer
@@ -3,6 +3,7 @@ Description=Perform remote backup four times daily
 
 [Timer]
 OnCalendar=0/6:00:00
+Persistent=true
 
 [Install]
 WantedBy=timers.target


### PR DESCRIPTION
Three small, independent fixes found while reviewing the config.

### nginx: clear Connection header for non-WebSocket requests
The `map $http_upgrade $connection_upgrade` block only had a `default upgrade` entry, so requests without an `Upgrade` header (all normal traffic) fell through to `default` and were proxied with `Connection: upgrade` and no accompanying `Upgrade` header. That is malformed per RFC 9110 §7.6.1 and is not the cleared `Connection` header nginx documents as required for the upstream `keepalive` enabled in the `backend`/`streaming` blocks.

Mapping the empty case to an empty value restores `Connection: ""` for normal requests (nginx omits empty-valued headers) while still sending `Connection: upgrade` for genuine WebSocket upgrades on `/api/v1/streaming`.

### remote-backup: run missed backups after downtime
`remote-backup.timer` had no `Persistent=true`, so a scheduled 6-hour run missed while the host was down (reboot/maintenance) was simply skipped with no catch-up on next boot. Added `Persistent=true`, which is the expected setting for an `OnCalendar` backup timer.

### restrict workflow token to read-only access
The lint workflow declared no `permissions:` block and inherited the default `GITHUB_TOKEN` scope. The job only checks out the repo and runs gixy, so it is restricted to `contents: read` (least privilege).